### PR TITLE
Mention hostname config setting

### DIFF
--- a/packages/gasket-plugin-https/README.md
+++ b/packages/gasket-plugin-https/README.md
@@ -37,6 +37,7 @@ You can specify what port to open up on, or what certificates to use via
 ```js
 // gasket.config.js
 module.exports = {
+  hostname: 'example.com',
   http: 80,
   https: {
     port: 443,


### PR DESCRIPTION
Add mention of hostname config setting in sample code. This is to clarify that you do not have to use gasket domain names